### PR TITLE
Fix some log warnings

### DIFF
--- a/src/gui/scene/renderer.cpp
+++ b/src/gui/scene/renderer.cpp
@@ -672,7 +672,7 @@ namespace Toolbox::UI {
                                      mouse_pos.y - m_window_rect.Min.y, 0};
 
         if (!left_click && !right_click) {
-            return {};
+            return std::nullopt;
         }
 
         should_reset = true;

--- a/src/gui/scene/renderer.cpp
+++ b/src/gui/scene/renderer.cpp
@@ -266,13 +266,18 @@ namespace Toolbox::UI {
                 return false;
             }
 
-            glDetachShader(pid, vs);
-            glDetachShader(pid, gs);
-            glDetachShader(pid, fs);
-
-            glDeleteShader(vs);
-            glDeleteShader(gs);
-            glDeleteShader(fs);
+            if (vertex_shader_src) {
+                glDetachShader(pid, vs);
+                glDeleteShader(vs);
+            }
+            if (geometry_shader_src) {
+                glDeleteShader(gs);
+                glDetachShader(pid, gs);
+            }
+            if (fragment_shader_src) {
+                glDeleteShader(fs);
+                glDetachShader(pid, fs);
+            }
 
             return true;
         }


### PR DESCRIPTION
Two commits, two fixes: an OpenGL error about detaching shaders that were never attached, and a null object warning in the scene view. The null object one might have just been a debug thing.