### PR TITLE
Native file dialogs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,3 +15,6 @@
 [submodule "lib/libbti"]
 	path = lib/libbti
 	url = https://github.com/HazardousPeach/libbti.git
+[submodule "lib/nativefiledialog"]
+	path = lib/nativefiledialog
+	url = git@github.com:mlabbe/nativefiledialog.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -15,6 +15,6 @@
 [submodule "lib/libbti"]
 	path = lib/libbti
 	url = https://github.com/HazardousPeach/libbti.git
-[submodule "lib/nativefiledialog"]
-	path = lib/nativefiledialog
-	url = git@github.com:mlabbe/nativefiledialog.git
+[submodule "lib/nativefiledialog-extended"]
+	path = lib/nativefiledialog-extended
+	url = git@github.com:btzy/nativefiledialog-extended.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,4 +17,4 @@
 	url = https://github.com/HazardousPeach/libbti.git
 [submodule "lib/nativefiledialog-extended"]
 	path = lib/nativefiledialog-extended
-	url = git@github.com:btzy/nativefiledialog-extended.git
+	url = https://github.com/btzy/nativefiledialog-extended.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,17 +115,22 @@ endif()
 find_package(Iconv REQUIRED)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(GTK REQUIRED gtk+-3.0)
+    include_directories(${GTK_INCLUDE_DIRS})
+    target_link_libraries(JuniorsToolbox PRIVATE j3dultra imgui glfw ${ICONV_LIBRARIES} tbb X11 GL ${GTK_LIBRARIES} glib)
   if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14)
-#    target_link_libraries(JuniorsToolbox PRIVATE j3dultra imgui glfw ICU::uc ICU::i18n stdc++exp tbb X11 GL)
-    target_link_libraries(JuniorsToolbox PRIVATE j3dultra imgui glfw ${ICONV_LIBRARIES} stdc++exp tbb X11 GL)
+    target_link_libraries(JuniorsToolbox PRIVATE stdc++exp)
   else()
-#    target_link_libraries(JuniorsToolbox PRIVATE j3dultra imgui glfw ICU::uc ICU::i18n stdc++_libbacktrace tbb X11 GL)
-    target_link_libraries(JuniorsToolbox PRIVATE j3dultra imgui glfw ${ICONV_LIBRARIES} stdc++_libbacktrace tbb X11 GL)
+    target_link_libraries(JuniorsToolbox PRIVATE stdc++_libbacktrace)
   endif()
 else()
 #  target_link_libraries(JuniorsToolbox PRIVATE j3dultra imgui glfw ICU::uc ICU::i18n)
   target_link_libraries(JuniorsToolbox PRIVATE j3dultra imgui glfw Iconv::Iconv)
 endif()
+
+find_library(NFD_PATH libnfd.a REQUIRED PATHS lib/nativefiledialog/build/lib/Release/x64)
+target_link_libraries(JuniorsToolbox PRIVATE ${NFD_PATH})
 
 if (WIN32)
 #  link this library so we can find Nahimic service
@@ -135,7 +140,7 @@ endif()
 
 target_compile_definitions(JuniorsToolbox PRIVATE NOMINMAX IMGUI_DEFINE_MATH_OPERATORS)
 
-target_include_directories(JuniorsToolbox PRIVATE "include" "lib" "lib/imgui" "lib/imgui/backends" "lib/nlohmann" "lib/glm::glm" "lib/J3DUltra" "lib/libbti" "lib/ImGuiFileDialog" "lib/glfw")
+target_include_directories(JuniorsToolbox PRIVATE "include" "lib" "lib/imgui" "lib/imgui/backends" "lib/nlohmann" "lib/glm::glm" "lib/J3DUltra" "lib/libbti" "lib/ImGuiFileDialog" "lib/glfw" "lib/nativefiledialog/src/include")
 
 
 add_custom_command(TARGET JuniorsToolbox PRE_BUILD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ include(lib/imgui.cmake)
 add_subdirectory(lib/J3DUltra)
 add_subdirectory(lib/libbti)
 add_subdirectory(lib/glfw)
+add_subdirectory(lib/nativefiledialog-extended)
 
 if(MSVC)
     # target_compile_options(j3dultra PRIVATE /w)
@@ -115,10 +116,10 @@ endif()
 find_package(Iconv REQUIRED)
 
 if(CMAKE_COMPILER_IS_GNUCXX)
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(GTK REQUIRED gtk+-3.0)
-    include_directories(${GTK_INCLUDE_DIRS})
-    target_link_libraries(JuniorsToolbox PRIVATE j3dultra imgui glfw ${ICONV_LIBRARIES} tbb X11 GL ${GTK_LIBRARIES} glib)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(GTK REQUIRED gtk+-3.0)
+  include_directories(${GTK_INCLUDE_DIRS})
+  target_link_libraries(JuniorsToolbox PRIVATE j3dultra imgui glfw ${ICONV_LIBRARIES} tbb X11 GL ${GTK_LIBRARIES} glib)
   if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 14)
     target_link_libraries(JuniorsToolbox PRIVATE stdc++exp)
   else()
@@ -129,8 +130,8 @@ else()
   target_link_libraries(JuniorsToolbox PRIVATE j3dultra imgui glfw Iconv::Iconv)
 endif()
 
-find_library(NFD_PATH libnfd.a REQUIRED PATHS lib/nativefiledialog/build/lib/Release/x64)
-target_link_libraries(JuniorsToolbox PRIVATE ${NFD_PATH})
+
+target_link_libraries(JuniorsToolbox PRIVATE nfd)
 
 if (WIN32)
 #  link this library so we can find Nahimic service
@@ -140,7 +141,7 @@ endif()
 
 target_compile_definitions(JuniorsToolbox PRIVATE NOMINMAX IMGUI_DEFINE_MATH_OPERATORS)
 
-target_include_directories(JuniorsToolbox PRIVATE "include" "lib" "lib/imgui" "lib/imgui/backends" "lib/nlohmann" "lib/glm::glm" "lib/J3DUltra" "lib/libbti" "lib/ImGuiFileDialog" "lib/glfw" "lib/nativefiledialog/src/include")
+target_include_directories(JuniorsToolbox PRIVATE "include" "lib" "lib/imgui" "lib/imgui/backends" "lib/nlohmann" "lib/glm::glm" "lib/J3DUltra" "lib/libbti" "lib/ImGuiFileDialog" "lib/glfw" "lib/nativefiledialog-extended/src/include")
 
 
 add_custom_command(TARGET JuniorsToolbox PRE_BUILD

--- a/include/core/application/application.hpp
+++ b/include/core/application/application.hpp
@@ -16,7 +16,7 @@
 #define EXIT_CODE_FAILED_SETUP    (1 << 28) | 2
 #define EXIT_CODE_FAILED_TEARDOWN (1 << 28) | 3
 
-#elifdef TOOLBOX_PLATFORM_LINUX
+#elif defined(TOOLBOX_PLATFORM_LINUX)
 
 #define EXIT_CODE_OK              0
 #define EXIT_CODE_FAILED_RUNTIME  1

--- a/include/core/mimedata/mimedata.hpp
+++ b/include/core/mimedata/mimedata.hpp
@@ -12,7 +12,7 @@
 
 #ifdef TOOLBOX_PLATFORM_WINDOWS
 #include <Windows.h>
-#elifdef TOOLBOX_PLATFORM_LINUX
+#elif defined(TOOLBOX_PLATFORM_LINUX)
 
 #else
 #error "Unsupported OS"
@@ -70,7 +70,7 @@ namespace Toolbox {
 #ifdef TOOLBOX_PLATFORM_WINDOWS
         static FORMATETC FormatForMime(std::string_view mimetype);
         static std::string MimeForFormat(FORMATETC format);
-#elifdef TOOLBOX_PLATFORM_LINUX
+#elif defined(TOOLBOX_PLATFORM_LINUX)
         static std::string UTIForMime(std::string_view mimetype);
         static std::string MimeForUTI(std::string_view uti);
 #endif

--- a/include/dolphin/hook.hpp
+++ b/include/dolphin/hook.hpp
@@ -15,7 +15,7 @@
 
 #ifdef TOOLBOX_PLATFORM_WINDOWS
 #include <Windows.h>
-#elifdef TOOLBOX_PLATFORM_LINUX
+#elif defined(TOOLBOX_PLATFORM_LINUX)
 #endif
 
 using namespace Toolbox;

--- a/include/gui/application.hpp
+++ b/include/gui/application.hpp
@@ -220,7 +220,7 @@ namespace Toolbox {
         std::vector<std::pair<std::string, std::string>> m_filters;
 
         // The result of the last dialog box.
-        nfdnchar_t *m_selected_path;
+        nfdu8char_t *m_selected_path;
         nfdresult_t m_result;
         // The thread that we run the dialog in. If
         // m_thread_initialized is true, this should be an initialized

--- a/include/gui/application.hpp
+++ b/include/gui/application.hpp
@@ -177,6 +177,21 @@ namespace Toolbox {
         Game::TaskCommunicator m_task_communicator;
     };
 
+    class FileDialogFilter {
+    public:
+        FileDialogFilter() = default;
+        ~FileDialogFilter() = default;
+
+        void AddFilter(const std::string &label, const std::string &csv_filters);
+        bool HasFilter(const std::string &label) const;
+        int NumFilters() const { return m_filters.size(); };
+        void WriteFiltersU8(nfdu8filteritem_t *&out) const;
+        void WriteFiltersN(nfdnfilteritem_t *&out) const;
+
+    private:
+        std::vector<std::pair<std::string, std::string>> m_filters;
+    };
+
     class FileDialog {
     public:
         FileDialog() = default;
@@ -192,7 +207,7 @@ namespace Toolbox {
         }
         void OpenDialog(std::filesystem::path starting_path, GLFWwindow *parent_window,
                         bool is_directory = false,
-                        std::optional<std::vector<std::pair<std::string, std::string>>>
+                        std::optional<FileDialogFilter>
                             maybe_filters = std::nullopt);
         bool IsAlreadyOpen() { return m_thread_running; }
         bool IsDone() { return !m_thread_running && !m_closed && m_thread_initialized; }

--- a/include/gui/application.hpp
+++ b/include/gui/application.hpp
@@ -182,11 +182,10 @@ namespace Toolbox {
         FileDialogFilter() = default;
         ~FileDialogFilter() = default;
 
-        void AddFilter(const std::string &label, const std::string &csv_filters);
-        bool HasFilter(const std::string &label) const;
-        int NumFilters() const { return m_filters.size(); };
-        void WriteFiltersU8(nfdu8filteritem_t *&out) const;
-        void WriteFiltersN(nfdnfilteritem_t *&out) const;
+        void addFilter(const std::string &label, const std::string &csv_filters);
+        bool hasFilter(const std::string &label) const;
+        int numFilters() const { return m_filters.size(); };
+        void writeFiltersU8(nfdu8filteritem_t *&out) const;
 
     private:
         std::vector<std::pair<std::string, std::string>> m_filters;
@@ -201,19 +200,19 @@ namespace Toolbox {
             }
         }
 
-        static FileDialog *Instance() {
+        static FileDialog *instance() {
             static FileDialog _instance;
             return &_instance;
         }
-        void OpenDialog(std::filesystem::path starting_path, GLFWwindow *parent_window,
+        void openDialog(std::filesystem::path starting_path, GLFWwindow *parent_window,
                         bool is_directory = false,
                         std::optional<FileDialogFilter>
                             maybe_filters = std::nullopt);
-        bool IsAlreadyOpen() { return m_thread_running; }
-        bool IsDone() { return !m_thread_running && !m_closed && m_thread_initialized; }
-        bool IsOk() { return m_result == NFD_OKAY; }
-        std::filesystem::path GetFilenameResult() { return m_selected_path; }
-        void Close() { m_closed = true; }
+        bool isAlreadyOpen() { return m_thread_running; }
+        bool isDone() { return !m_thread_running && !m_closed && m_thread_initialized; }
+        bool isOk() { return m_result == NFD_OKAY; }
+        std::filesystem::path getFilenameResult() { return m_selected_path; }
+        void close() { m_closed = true; }
 
     private:
         std::string m_starting_path;

--- a/include/gui/application.hpp
+++ b/include/gui/application.hpp
@@ -194,11 +194,21 @@ namespace Toolbox {
         std::filesystem::path GetFilenameResult() { return m_selected_path; }
         void Close() { m_closed = true;}
     private:
+        // The result of the last dialog box.
         nfdchar_t* m_selected_path;
         nfdresult_t m_result;
+        // The thread that we run the dialog in. If
+        // m_thread_initialized is true, this should be an initialized
+        // thread object.
         std::thread m_thread;
+        // For tracking whether we've launched any threads so far. If
+        // so, we'll join them before launching another.
         bool m_thread_initialized = false;
+        // For tracking whether the thread is still running a dialog
+        // box.
         bool m_thread_finished = false;
+        // For checking whether the user has called Close. If so, stop
+        // returning true for isDone().
         bool m_closed = false;
     };
 

--- a/include/gui/application.hpp
+++ b/include/gui/application.hpp
@@ -185,7 +185,9 @@ namespace Toolbox {
             return &_instance;
         }
         void OpenDialog(std::filesystem::path starting_path,
-                        bool is_directory = false);
+                        bool is_directory = false,
+                        std::optional<std::vector<std::pair<
+                        const char*, const char*>>> maybe_filters = std::nullopt);
         bool isDone() { return m_thread_finished && not m_closed; }
         bool isOk() { return m_result == NFD_OKAY; }
         std::filesystem::path GetFilenameResult() { return m_selected_path; }

--- a/include/gui/application.hpp
+++ b/include/gui/application.hpp
@@ -194,9 +194,9 @@ namespace Toolbox {
                         bool is_directory = false,
                         std::optional<std::vector<std::pair<std::string, std::string>>>
                             maybe_filters = std::nullopt);
-        bool isAlreadyOpen() { return m_thread_running; }
-        bool isDone() { return !m_thread_running && !m_closed && m_thread_initialized; }
-        bool isOk() { return m_result == NFD_OKAY; }
+        bool IsAlreadyOpen() { return m_thread_running; }
+        bool IsDone() { return !m_thread_running && !m_closed && m_thread_initialized; }
+        bool IsOk() { return m_result == NFD_OKAY; }
         std::filesystem::path GetFilenameResult() { return m_selected_path; }
         void Close() { m_closed = true; }
 

--- a/include/gui/application.hpp
+++ b/include/gui/application.hpp
@@ -23,6 +23,7 @@
 #include "dolphin/process.hpp"
 
 #include "scene/layout.hpp"
+#include <nfd.h>
 
 using namespace Toolbox::Dolphin;
 
@@ -175,6 +176,26 @@ namespace Toolbox {
         std::thread m_thread_templates_init;
         DolphinCommunicator m_dolphin_communicator;
         Game::TaskCommunicator m_task_communicator;
+    };
+
+    class FileDialog {
+    public:
+        static FileDialog* Instance() {
+            static FileDialog _instance;
+            return &_instance;
+        }
+        void OpenDialog(std::filesystem::path starting_path,
+                        bool is_directory = false);
+        bool isDone() { return m_thread_finished && not m_closed; }
+        bool isOk() { return m_result == NFD_OKAY; }
+        std::filesystem::path GetFilenameResult() { return m_selected_path; }
+        void Close() { m_closed = true;}
+    private:
+        nfdchar_t* m_selected_path;
+        nfdresult_t m_result;
+        std::thread m_thread;
+        bool m_thread_finished;
+        bool m_closed = false;
     };
 
 }  // namespace Toolbox

--- a/include/gui/application.hpp
+++ b/include/gui/application.hpp
@@ -216,13 +216,8 @@ namespace Toolbox {
         void Close() { m_closed = true; }
 
     private:
-#ifdef TOOLBOX_PLATFORM_WINDOWS
-        std::wstring m_starting_path;
-        std::vector<std::pair<std::wstring, std::wstring>> m_filters;
-#else
         std::string m_starting_path;
         std::vector<std::pair<std::string, std::string>> m_filters;
-#endif
 
         // The result of the last dialog box.
         nfdnchar_t *m_selected_path;

--- a/include/gui/application.hpp
+++ b/include/gui/application.hpp
@@ -185,6 +185,7 @@ namespace Toolbox {
             return &_instance;
         }
         void OpenDialog(std::filesystem::path starting_path,
+                        GLFWwindow* parent_window,
                         bool is_directory = false,
                         std::optional<std::vector<std::pair<
                         const char*, const char*>>> maybe_filters = std::nullopt);

--- a/include/gui/application.hpp
+++ b/include/gui/application.hpp
@@ -194,7 +194,8 @@ namespace Toolbox {
         nfdchar_t* m_selected_path;
         nfdresult_t m_result;
         std::thread m_thread;
-        bool m_thread_finished;
+        bool m_thread_initialized = false;
+        bool m_thread_finished = false;
         bool m_closed = false;
     };
 

--- a/include/gui/application.hpp
+++ b/include/gui/application.hpp
@@ -188,6 +188,7 @@ namespace Toolbox {
                         bool is_directory = false,
                         std::optional<std::vector<std::pair<
                         const char*, const char*>>> maybe_filters = std::nullopt);
+        bool isAlreadyOpen() { return not m_thread_finished; }
         bool isDone() { return m_thread_finished && not m_closed; }
         bool isOk() { return m_result == NFD_OKAY; }
         std::filesystem::path GetFilenameResult() { return m_selected_path; }

--- a/include/gui/application.hpp
+++ b/include/gui/application.hpp
@@ -118,7 +118,7 @@ namespace Toolbox {
         Game::TaskCommunicator &getTaskCommunicator() { return m_task_communicator; }
 
         std::filesystem::path getProjectRoot() const { return m_project_root; }
-        
+
 
         void registerDolphinOverlay(UUID64 scene_uuid, const std::string &name,
                                     SceneWindow::render_layer_cb cb);
@@ -188,8 +188,8 @@ namespace Toolbox {
                         bool is_directory = false,
                         std::optional<std::vector<std::pair<
                         const char*, const char*>>> maybe_filters = std::nullopt);
-        bool isAlreadyOpen() { return not m_thread_finished; }
-        bool isDone() { return m_thread_finished && not m_closed; }
+        bool isAlreadyOpen() { return m_thread_running; }
+        bool isDone() { return !m_thread_running && not m_closed; }
         bool isOk() { return m_result == NFD_OKAY; }
         std::filesystem::path GetFilenameResult() { return m_selected_path; }
         void Close() { m_closed = true;}
@@ -206,7 +206,7 @@ namespace Toolbox {
         bool m_thread_initialized = false;
         // For tracking whether the thread is still running a dialog
         // box.
-        bool m_thread_finished = false;
+        bool m_thread_running = false;
         // For checking whether the user has called Close. If so, stop
         // returning true for isDone().
         bool m_closed = false;

--- a/include/gui/application.hpp
+++ b/include/gui/application.hpp
@@ -185,7 +185,7 @@ namespace Toolbox {
         void addFilter(const std::string &label, const std::string &csv_filters);
         bool hasFilter(const std::string &label) const;
         int numFilters() const { return m_filters.size(); };
-        void writeFiltersU8(nfdu8filteritem_t *&out) const;
+        void copyFiltersOutU8(std::vector<std::pair<std::string, std::string>> &out_filters) const;
 
     private:
         std::vector<std::pair<std::string, std::string>> m_filters;

--- a/include/platform/process.hpp
+++ b/include/platform/process.hpp
@@ -7,7 +7,7 @@
 
 #ifdef TOOLBOX_PLATFORM_WINDOWS
 #include <Windows.h>
-#elifdef TOOLBOX_PLATFORM_LINUX
+#elif defined(TOOLBOX_PLATFORM_LINUX)
 #include <sys/types.h>
 #include <unistd.h>
 #endif
@@ -20,7 +20,7 @@ namespace Toolbox::Platform {
     typedef HWND LowWindow;
     typedef void* MemHandle;
 #define NULL_MEMHANDLE nullptr
-#elifdef TOOLBOX_PLATFORM_LINUX
+#elif defined(TOOLBOX_PLATFORM_LINUX)
     typedef void *LowHandle;
     typedef pid_t ProcessID;
     typedef void *LowWindow;

--- a/src/core/mimedata/mimedata.cpp
+++ b/src/core/mimedata/mimedata.cpp
@@ -143,7 +143,7 @@ namespace Toolbox {
     FORMATETC MimeData::FormatForMime(std::string_view mimetype) { return FORMATETC(); }
 
     std::string MimeData::MimeForFormat(FORMATETC format) { return std::string(); }
-#elifdef TOOLBOX_PLATFORM_LINUX
+#elif defined(TOOLBOX_PLATFORM_LINUX)
     static std::unordered_map<std::string, std::string> s_uti_to_mime = {
         {"public.utf8-plain-text",               "text/plain"            },
         {"public.utf16-plain-text",              "text/plain"            },

--- a/src/dolphin/hook.cpp
+++ b/src/dolphin/hook.cpp
@@ -93,7 +93,7 @@ namespace Toolbox::Dolphin {
         return GetCommState(handle, &flags);
     }
 
-#elifdef TOOLBOX_PLATFORM_LINUX
+#elif defined(TOOLBOX_PLATFORM_LINUX)
     static Result<Platform::ProcessID, BaseError> FindProcessPID(std::string_view process_name) {
         std::array<char, 128> buffer;
         std::string pidof_cmd = "pidof ";

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -606,7 +606,7 @@ namespace Toolbox {
         m_thread_running = true;
         m_closed         = false;
         auto fn          = [this, starting_path, parent_window, is_directory, maybe_filters]() {
-            m_starting_path = starting_path.wstring();
+            m_starting_path = starting_path.string();
             m_filters.clear();
             if (is_directory) {
                 nfdpickfoldernargs_t args;

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -400,15 +400,15 @@ namespace Toolbox {
         ImGui::EndMainMenuBar();
 
         if (m_is_dir_dialog_open) {
-            if (!FileDialog::Instance()->IsAlreadyOpen()) {
-                FileDialog::Instance()->OpenDialog(m_load_path, m_render_window, true);
+            if (!FileDialog::instance()->isAlreadyOpen()) {
+                FileDialog::instance()->openDialog(m_load_path, m_render_window, true);
             }
             m_is_dir_dialog_open = false;
         }
-        if (FileDialog::Instance()->IsDone()) {
-            FileDialog::Instance()->Close();
-            if (FileDialog::Instance()->IsOk()) {
-                std::filesystem::path selected_path = FileDialog::Instance()->GetFilenameResult();
+        if (FileDialog::instance()->isDone()) {
+            FileDialog::instance()->close();
+            if (FileDialog::instance()->isOk()) {
+                std::filesystem::path selected_path = FileDialog::instance()->getFilenameResult();
                 std::cout << "Selected path is " << selected_path.string() << std::endl;
                 if (selected_path.filename() == "scene") {
                     RefPtr<ImWindow> existing_editor =
@@ -443,17 +443,17 @@ namespace Toolbox {
         }
 
         if (m_is_file_dialog_open) {
-            if (!FileDialog::Instance()->IsAlreadyOpen()) {
+            if (!FileDialog::instance()->isAlreadyOpen()) {
                 FileDialogFilter filter;
-                filter.AddFilter("Nintendo Scene Archive", "szs,arc");
-                FileDialog::Instance()->OpenDialog(m_load_path, m_render_window, false, filter);
+                filter.addFilter("Nintendo Scene Archive", "szs,arc");
+                FileDialog::instance()->openDialog(m_load_path, m_render_window, false, filter);
             }
             m_is_file_dialog_open = false;
         }
-        if (FileDialog::Instance()->IsDone()) {
-            FileDialog::Instance()->Close();
-            if (FileDialog::Instance()->IsOk()) {
-                std::filesystem::path selected_path = FileDialog::Instance()->GetFilenameResult();
+        if (FileDialog::instance()->isDone()) {
+            FileDialog::instance()->close();
+            if (FileDialog::instance()->isOk()) {
+                std::filesystem::path selected_path = FileDialog::instance()->getFilenameResult();
                 if (selected_path.extension() == ".szs" || selected_path.extension() == ".arc") {
                     RefPtr<SceneWindow> window = createWindow<SceneWindow>("Scene Editor");
                     if (!window->onLoadData(selected_path)) {
@@ -544,7 +544,7 @@ namespace Toolbox {
         }
     }
 
-    void FileDialog::OpenDialog(
+    void FileDialog::openDialog(
         std::filesystem::path starting_path, GLFWwindow *parent_window, bool is_directory,
         std::optional<FileDialogFilter> maybe_filters) {
         if (m_thread_initialized) {
@@ -567,9 +567,9 @@ namespace Toolbox {
                 nfdu8filteritem_t *nfd_filters = nullptr;
                 if (maybe_filters) {
                     auto filters = maybe_filters.value();
-                    num_filters  = filters.NumFilters();
+                    num_filters  = filters.numFilters();
                     nfd_filters  = new nfdu8filteritem_t[num_filters];
-                    filters.WriteFiltersU8(nfd_filters);
+                    filters.writeFiltersU8(nfd_filters);
                 }
                 nfdopendialogu8args_t args;
                 args.filterList  = const_cast<const nfdu8filteritem_t *>(nfd_filters);
@@ -586,16 +586,16 @@ namespace Toolbox {
         m_thread = std::thread(fn);
     }
 
-    void FileDialogFilter::AddFilter(const std::string &label, const std::string &csv_filters){
+    void FileDialogFilter::addFilter(const std::string &label, const std::string &csv_filters){
         m_filters.push_back({std::string(label), std::string(csv_filters)});
     }
-    bool FileDialogFilter::HasFilter(const std::string &label) const {
+    bool FileDialogFilter::hasFilter(const std::string &label) const {
         return std::find_if(m_filters.begin(), m_filters.end(),
                             [label](std::pair<std::string, std::string> p){
                                 return p.first == label;
                             }) != m_filters.end();
     }
-    void FileDialogFilter::WriteFiltersU8(nfdu8filteritem_t *&out) const {
+    void FileDialogFilter::writeFiltersU8(nfdu8filteritem_t *&out) const {
         for(int i = 0; i < m_filters.size(); ++i) {
             char* name = new char[m_filters[i].first.length()];
             char* spec = new char[m_filters[i].second.length()];

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -563,8 +563,6 @@ namespace Toolbox {
                 args.defaultPath = m_starting_path.c_str();
                 NFD_GetNativeWindowFromGLFWWindow(parent_window, &args.parentWindow);
                 m_result = NFD_PickFolderN_With(&m_selected_path, &args);
-                TOOLBOX_INFO_V("Selected path: {}", std::filesystem::path(m_selected_path).string());
-                TOOLBOX_INFO_V("Result: {}", int(m_result));
                 // m_result = NFD_PickFolderN(&m_selected_path, starting_path.string().c_str());
             } else {
                 int num_filters               = 0;

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -572,6 +572,9 @@ namespace Toolbox {
                 m_result = NFD_OpenDialog(&m_selected_path, nfd_filters, num_filters,
                                           starting_path.string().c_str());
             }
+            if(maybe_filters) {
+                delete[] nfd_filters;
+            }
             m_thread_finished = true;
         };
         m_thread = std::thread(fn);

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -226,6 +226,8 @@ namespace Toolbox {
 
         m_dolphin_communicator.tKill(true);
         m_task_communicator.tKill(true);
+
+        NFD_Quit();
     }
 
     Toolbox::fs_path GUIApplication::getResourcePath(const Toolbox::fs_path &path) const & {

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -559,7 +559,7 @@ namespace Toolbox {
         } else {
             m_thread_initialized = true;
         }
-        m_thread_finished = false;
+        m_thread_running = true;
         auto fn = [this, is_directory, starting_path, maybe_filters]
                                () {
             int num_filters = 0;
@@ -582,7 +582,7 @@ namespace Toolbox {
             if(maybe_filters) {
                 delete[] nfd_filters;
             }
-            m_thread_finished = true;
+            m_thread_running = false;
         };
         m_thread = std::thread(fn);
     }

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -397,7 +397,9 @@ namespace Toolbox {
         ImGui::EndMainMenuBar();
 
         if (m_is_dir_dialog_open) {
-            FileDialog::Instance()->OpenDialog(m_load_path, true);
+            if (!FileDialog::Instance()->isAlreadyOpen()) {
+                FileDialog::Instance()->OpenDialog(m_load_path, true);
+            }
             m_is_dir_dialog_open = false;
         }
         if (FileDialog::Instance()->isDone()) {
@@ -441,10 +443,12 @@ namespace Toolbox {
         }
 
         if (m_is_file_dialog_open) {
-            std::vector<std::pair<const char*, const char*>> filters;
-            filters.push_back({"Nintendo Scene Archive", "szs,arc"});
-            FileDialog::Instance()->OpenDialog(m_load_path, false,
-                                               filters);
+            if (!FileDialog::Instance()->isAlreadyOpen()) {
+                std::vector<std::pair<const char*, const char*>> filters;
+                filters.push_back({"Nintendo Scene Archive", "szs,arc"});
+                FileDialog::Instance()->OpenDialog(m_load_path, false,
+                                                   filters);
+            }
             m_is_file_dialog_open = false;
         }
         if (FileDialog::Instance()->isDone()) {
@@ -553,6 +557,7 @@ namespace Toolbox {
         } else {
             m_thread_initialized = true;
         }
+        m_thread_finished = false;
         auto fn = [this, is_directory, starting_path, maybe_filters]
                                () {
             int num_filters = 0;

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -543,6 +543,11 @@ namespace Toolbox {
 
     void FileDialog::OpenDialog(std::filesystem::path starting_path,
                                 bool is_directory) {
+        if (m_thread_initialized) {
+            m_thread.join();
+        } else {
+            m_thread_initialized = true;
+        }
         auto fn = [is_directory, this, starting_path]
                                () {
             if(is_directory){

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -565,11 +565,11 @@ namespace Toolbox {
         auto fn = [this, starting_path, parent_window, is_directory, maybe_filters]
                                () {
             if(is_directory){
-                // nfdpickfoldernargs_t args;
-                // args.defaultPath = starting_path.string().c_str();
-                // NFD_GetNativeWindowFromGLFWWindow(parent_window, &args.parentWindow);
-                // m_result = NFD_PickFolderN_With(&m_selected_path, &args);
-                m_result = NFD_PickFolderN(&m_selected_path, starting_path.string().c_str());
+                nfdpickfoldernargs_t args;
+                args.defaultPath = starting_path.string().c_str();
+                NFD_GetNativeWindowFromGLFWWindow(parent_window, &args.parentWindow);
+                m_result = NFD_PickFolderN_With(&m_selected_path, &args);
+                //m_result = NFD_PickFolderN(&m_selected_path, starting_path.string().c_str());
             } else {
                 int num_filters = 0;
                 nfdu8filteritem_t* nfd_filters = nullptr;
@@ -586,7 +586,7 @@ namespace Toolbox {
                 args.filterList = nfd_filters;
                 args.filterCount = num_filters;
                 args.defaultPath = starting_path.string().c_str();
-                // NFD_GetNativeWindowFromGLFWWindow(parent_window, &args.parentWindow);
+                NFD_GetNativeWindowFromGLFWWindow(parent_window, &args.parentWindow);
                 m_result = NFD_OpenDialogN_With(&m_selected_path, &args);
                 if(maybe_filters) {
                     delete[] nfd_filters;

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -556,7 +556,6 @@ namespace Toolbox {
         m_closed         = false;
         auto fn          = [this, starting_path, parent_window, is_directory, maybe_filters]() {
             m_starting_path = starting_path.string();
-            m_filters.clear();
             if (is_directory) {
                 nfdpickfolderu8args_t args;
                 args.defaultPath = m_starting_path.c_str();
@@ -567,9 +566,12 @@ namespace Toolbox {
                 nfdu8filteritem_t *nfd_filters = nullptr;
                 if (maybe_filters) {
                     auto filters = maybe_filters.value();
-                    num_filters  = filters.numFilters();
-                    nfd_filters  = new nfdu8filteritem_t[num_filters];
-                    filters.writeFiltersU8(nfd_filters);
+                    num_filters = filters.numFilters();
+                    filters.copyFiltersOutU8(m_filters);
+                    nfd_filters = new nfdu8filteritem_t[num_filters];
+                    for (int i = 0; i < filters.numFilters(); ++i){
+                        nfd_filters[i] = {m_filters[i].first.c_str(), m_filters[i].second.c_str()};
+                    }
                 }
                 nfdopendialogu8args_t args;
                 args.filterList  = const_cast<const nfdu8filteritem_t *>(nfd_filters);
@@ -595,14 +597,9 @@ namespace Toolbox {
                                 return p.first == label;
                             }) != m_filters.end();
     }
-    void FileDialogFilter::writeFiltersU8(nfdu8filteritem_t *&out) const {
-        for(int i = 0; i < m_filters.size(); ++i) {
-            char* name = new char[m_filters[i].first.length()];
-            char* spec = new char[m_filters[i].second.length()];
-            std::strcpy(name, m_filters[i].first.c_str());
-            std::strcpy(spec, m_filters[i].second.c_str());
-            out[i] = {name, spec};
-        }
+
+    void FileDialogFilter::copyFiltersOutU8(std::vector<std::pair<std::string, std::string>> &out_filters) const {
+        out_filters = m_filters;
     }
 }  // namespace Toolbox
 

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -400,14 +400,14 @@ namespace Toolbox {
         ImGui::EndMainMenuBar();
 
         if (m_is_dir_dialog_open) {
-            if (!FileDialog::Instance()->isAlreadyOpen()) {
+            if (!FileDialog::Instance()->IsAlreadyOpen()) {
                 FileDialog::Instance()->OpenDialog(m_load_path, m_render_window, true);
             }
             m_is_dir_dialog_open = false;
         }
-        if (FileDialog::Instance()->isDone()) {
+        if (FileDialog::Instance()->IsDone()) {
             FileDialog::Instance()->Close();
-            if (FileDialog::Instance()->isOk()) {
+            if (FileDialog::Instance()->IsOk()) {
                 std::filesystem::path selected_path = FileDialog::Instance()->GetFilenameResult();
                 std::cout << "Selected path is " << selected_path.string() << std::endl;
                 if (selected_path.filename() == "scene") {
@@ -443,16 +443,16 @@ namespace Toolbox {
         }
 
         if (m_is_file_dialog_open) {
-            if (!FileDialog::Instance()->isAlreadyOpen()) {
+            if (!FileDialog::Instance()->IsAlreadyOpen()) {
                 std::vector<std::pair<std::string, std::string>> filters;
                 filters.push_back({"Nintendo Scene Archive", "szs,arc"});
                 FileDialog::Instance()->OpenDialog(m_load_path, m_render_window, false, filters);
             }
             m_is_file_dialog_open = false;
         }
-        if (FileDialog::Instance()->isDone()) {
+        if (FileDialog::Instance()->IsDone()) {
             FileDialog::Instance()->Close();
-            if (FileDialog::Instance()->isOk()) {
+            if (FileDialog::Instance()->IsOk()) {
                 std::filesystem::path selected_path = FileDialog::Instance()->GetFilenameResult();
                 if (selected_path.extension() == ".szs" || selected_path.extension() == ".arc") {
                     RefPtr<SceneWindow> window = createWindow<SceneWindow>("Scene Editor");

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -450,7 +450,7 @@ namespace Toolbox {
                 std::filesystem::path selected_path =
                     FileDialog::Instance()->GetFilenameResult();
                 if (selected_path.extension() == ".szs" ||
-                    selected_path.extension() == ".arg") {
+                    selected_path.extension() == ".arc") {
                      RefPtr<SceneWindow> window = createWindow<SceneWindow>("Scene Editor");
                      if (!window->onLoadData(selected_path)) {
                          window->close();

--- a/src/gui/application.cpp
+++ b/src/gui/application.cpp
@@ -644,7 +644,11 @@ namespace Toolbox {
     }
     void FileDialogFilter::WriteFiltersU8(nfdu8filteritem_t *&out) const {
         for(int i = 0; i < m_filters.size(); ++i) {
-            out[i] = {m_filters[i].first.c_str(), m_filters[i].second.c_str()};
+            char* name = new char[m_filters[i].first.length()];
+            char* spec = new char[m_filters[i].second.length()];
+            std::strcpy(name, m_filters[i].first.c_str());
+            std::strcpy(spec, m_filters[i].second.c_str());
+            out[i] = {name, spec};
         }
     }
 #ifdef TOOLBOX_PLATFORM_WINDOWS

--- a/src/gui/imgui_ext.cpp
+++ b/src/gui/imgui_ext.cpp
@@ -5,7 +5,7 @@
 
 #ifdef TOOLBOX_PLATFORM_WINDOWS
 #include <glfw/glfw3.h>
-#elifdef TOOLBOX_PLATFORM_LINUX
+#elif defined(TOOLBOX_PLATFORM_LINUX)
 #include <GLFW/glfw3.h>
 #endif
 #include <imgui_impl_glfw.cpp>

--- a/src/platform/capture.cpp
+++ b/src/platform/capture.cpp
@@ -105,7 +105,7 @@ namespace Toolbox::Platform {
 
         return texture_id;
     }
-#elifdef TOOLBOX_PLATFORM_LINUX
+#elif defined(TOOLBOX_PLATFORM_LINUX)
 #endif
 
 }  // namespace Toolbox::Platform

--- a/src/platform/process.cpp
+++ b/src/platform/process.cpp
@@ -10,7 +10,7 @@
 #ifdef TOOLBOX_PLATFORM_WINDOWS
 #include <TlHelp32.h>
 #include <Windows.h>
-#elifdef TOOLBOX_PLATFORM_LINUX
+#elif defined(TOOLBOX_PLATFORM_LINUX)
 #include <limits>
 #include <string.h>
 #include <signal.h>
@@ -187,7 +187,7 @@ namespace Toolbox::Platform {
         return UpdateWindow(window);
     }
 
-#elifdef TOOLBOX_PLATFORM_LINUX
+#elif defined(TOOLBOX_PLATFORM_LINUX)
     std::string GetLastErrorMessage() { return strerror(errno); }
 
     Result<ProcessInformation> CreateExProcess(const std::filesystem::path &program_path,

--- a/src/platform/service.cpp
+++ b/src/platform/service.cpp
@@ -46,7 +46,7 @@ namespace Toolbox::Platform {
 
         return isRunning;
     }
-#elifdef TOOLBOX_PLATFORM_LINUX
+#elif defined(TOOLBOX_PLATFORM_LINUX)
     Result<bool, BaseError> IsServiceRunning(std::string_view name) {
       return false;
     }

--- a/src/scene/layout.cpp
+++ b/src/scene/layout.cpp
@@ -42,6 +42,12 @@ namespace Toolbox::Scene {
                 std::ifstream file(path, std::ios::binary);
                 Deserializer in(file.rdbuf());
 
+                if (&m_scene_layout == nullptr) {
+                    TOOLBOX_INFO("Failed to load from path because m_scene_layout "
+                                 "was never initialized");
+                    return Result<bool, FSError>();
+                }
+
                 m_scene_layout->deserialize(in).or_else([&](const SerialError &error) {
                     result = false;
                     LogError(error);


### PR DESCRIPTION
Use the nativefiledialog-extended library to provide cross-platform native file dialogs instead of using ImGuiFileDialog. These file dialogs will render in their own thread.