### PR TITLE
Don't pass the -d and -c flags to dolphin if it's dolphin-emu-nogui

### DIFF
--- a/src/dolphin/hook.cpp
+++ b/src/dolphin/hook.cpp
@@ -15,6 +15,8 @@
 #include <sys/stat.h>
 #endif
 
+using std::string_view_literals::operator""sv;
+
 namespace Toolbox::Dolphin {
 
 #ifdef TOOLBOX_PLATFORM_WINDOWS
@@ -174,7 +176,14 @@ namespace Toolbox::Dolphin {
         }
 
         std::string dolphin_args =
-            std::format("-e {}/sys/main.dol -d -c -a HLE", application.getProjectRoot().string());
+            std::format("-e {}/sys/main.dol -a HLE", application.getProjectRoot().string());
+
+        std::string dolphin_path = std::string(settings.m_dolphin_path);
+        size_t last_not_null = dolphin_path.find_last_not_of('\000');
+        std::string used_substr = dolphin_path.substr(last_not_null - 5, last_not_null);
+        if (!used_substr.starts_with("-nogui"sv)){
+          dolphin_args += "-d -c";
+        }
 #ifdef TOOLBOX_PLATFORM_LINUX
         // Force dolphin to run on X11 instead of Wayland if running on Linux
         putenv("QT_QPA_PLATFORM=xcb");

--- a/src/dolphin/hook.cpp
+++ b/src/dolphin/hook.cpp
@@ -178,7 +178,7 @@ namespace Toolbox::Dolphin {
         std::string dolphin_args =
             std::format("-e {}/sys/main.dol -a HLE", application.getProjectRoot().string());
 
-        std::string dolphin_path = std::string(settings.m_dolphin_path);
+        std::string dolphin_path = settings.m_dolphin_path.string();
         size_t last_not_null = dolphin_path.find_last_not_of('\000');
         std::string used_substr = dolphin_path.substr(last_not_null - 5, last_not_null);
         if (!used_substr.starts_with("-nogui"sv)){


### PR DESCRIPTION
This allows users to use dolphin-emu-nogui instead of dolphin-emu as their player. I originally wanted this because the branch I've been building custom dolphin off is only building the nogui version. Addresses #30 